### PR TITLE
fix(rook-ceph): valid ceph-csi sidecar resources (unblock v1.20 migration)

### DIFF
--- a/kubernetes/apps/infrastructure/storage/rook-ceph/ceph-csi-drivers/helmrelease.yaml
+++ b/kubernetes/apps/infrastructure/storage/rook-ceph/ceph-csi-drivers/helmrelease.yaml
@@ -37,6 +37,9 @@ spec:
                 memory: 512Mi
               limits:
                 memory: 1Gi
+            liveness: {}
+            addons: {}
+            logRotator: {}
         nodePlugin: &nodePlugin
           priorityClassName: system-node-critical
           resources:
@@ -52,6 +55,9 @@ spec:
                 memory: 128Mi
               limits:
                 memory: 256Mi
+            liveness: {}
+            addons: {}
+            logRotator: {}
       cephfs:
         enabled: true
         name: rook-ceph.cephfs.csi.ceph.com
@@ -72,6 +78,10 @@ spec:
                 memory: 512Mi
               limits:
                 memory: 1Gi
+            omapGenerator: {}
+            liveness: {}
+            addons: {}
+            logRotator: {}
         nodePlugin: *nodePlugin
       nfs:
         enabled: false


### PR DESCRIPTION
PR #227 merged but the `ceph-csi-drivers` HelmRelease install failed: the chart emits `null` for untuned sidecar resource keys, which the Driver CRD rejects (`must be of type object`). This sets the untuned sidecars (liveness/addons/logRotator/omapGenerator) to `{}` so the tuned sidecars keep their requests/limits and the Driver CRs validate.

Validated via server-side dry-run against the live CRD — both Driver CRs apply cleanly. Unblocks the stuck Ceph v1.20 / CSI migration (currently gated, existing mounts unaffected).