### PR TITLE
fix(rook-ceph): enable RBD CSI snapshotter

### DIFF
--- a/kubernetes/apps/infrastructure/storage/rook-ceph/ceph-csi-drivers/helmrelease.yaml
+++ b/kubernetes/apps/infrastructure/storage/rook-ceph/ceph-csi-drivers/helmrelease.yaml
@@ -13,6 +13,7 @@ spec:
       rbd:
         enabled: true
         name: rook-ceph.rbd.csi.ceph.com
+        snapshotPolicy: volumeSnapshot
         controllerPlugin:
           replicas: 2
           priorityClassName: system-cluster-critical


### PR DESCRIPTION
## Problem

Since the rook-ceph **v1.20 bump** (#227 / #399, merged 06-19 evening) migrated CSI to the new ceph-csi-operator + `ceph-csi-drivers` chart, **all volsync RBD ReplicationSources have been wedged**. The operator logs ~50/hr of:

> `data PVC not available (possibly waiting for copy trigger)`

That's a symptom: volsync is correctly waiting on its source VolumeSnapshot, but every `volsync-*-src` RBD snapshot sits at `readyToUse=false` with empty status — never processed.

## Root cause

The new ceph-csi-operator only deploys the `csi-snapshotter` sidecar when a Driver's `snapshotPolicy != none`. The `rbd` block left `snapshotPolicy` **unset** (defaults to `none`), so the live rbd `ctrlplugin` pod runs without a snapshotter — nothing ever calls `CreateSnapshot` on the RBD backend.

CephFS was unaffected because it sets `snapshotPolicy: volumeGroupSnapshot`, which is why immich / share-backup (the only `csi-ceph-filesystem` sources) kept backing up fine.

## Fix

Set `snapshotPolicy: volumeSnapshot` on the rbd driver (plain VolumeSnapshots, which is what volsync uses — no group-snapshot machinery needed).

## Follow-up after merge/reconcile

The 11 stale `volsync-*-src` snapshots (empty status) likely need deleting by hand — volsync already hit `... already exists` trying to recreate them.